### PR TITLE
Add support for RetroWave OPL3 serial protocol

### DIFF
--- a/notesaladtools/devices.py
+++ b/notesaladtools/devices.py
@@ -1,4 +1,4 @@
-from .opl import OPLController, OPLUSBSerial, OPLWAV, OPLEmulator
+from .opl import OPLController, OPLUSBSerial, OPLWAV, OPLEmulator, RetroWaveOPL3
 from .opm import OPMController, OPMUSBSerial, OPMWAV, OPMEmulator
 
 
@@ -13,6 +13,8 @@ def get_device(name):
         (devtype, path) = parts
         if devtype == 'oplser':
             return OPLController(OPLUSBSerial(path))
+        if devtype == 'rwave':
+            return OPLController(RetroWaveOPL3(path))
         if devtype == 'oplwav':
             return OPLController(OPLWAV(path))
         if devtype == 'opmser':

--- a/notesaladtools/opl.py
+++ b/notesaladtools/opl.py
@@ -256,9 +256,7 @@ class RetroWaveOPL3(OPLChip):
 
     def reset(self):
         self._spi_write((0x42, 0x12, 0xfe))
-        time.sleep(0.1)
         self._spi_write((0x42, 0x12, 0xff))
-        time.sleep(0.1)
         self.buffered_writes = []
 
 

--- a/notesaladtools/utils.py
+++ b/notesaladtools/utils.py
@@ -39,3 +39,25 @@ def convert_time_base(src_time, src_time_base, dest_time_base):
     seconds = src_time // src_time_base
     fraction = (src_time % src_time_base) / src_time_base
     return round((seconds * dest_time_base) + (fraction * dest_time_base))
+
+
+def retrowave_7bit_encode(data: bytes, flag: bool) -> bytes:
+    output = bytearray()
+
+    if len(data) < 1:
+        return output
+
+    flag_bit = 0x01 if flag else 0x00
+
+    bit_offset = 0
+    for input_byte in data:
+        if bit_offset == 0:
+            output.append(input_byte | flag_bit)
+            output.append(((input_byte << 7) & 0xff) | flag_bit)
+            bit_offset = 2
+        else:
+            output[-1] |= (input_byte >> (bit_offset - 1)) & 0x7f
+            output.append(((input_byte << (8 - bit_offset)) & 0xff) | flag_bit)
+            bit_offset = (bit_offset + 1) % 8
+
+    return output


### PR DESCRIPTION
Enables playing VGM files using a RetroWave OPL3 or opl2sd1 device with nsplay, e.g.:

```
nsplay -d rwave:/dev/cu.usbmodem2201 <VGM file path>
```